### PR TITLE
optimize Lsh and Rsh

### DIFF
--- a/fixedbig.go
+++ b/fixedbig.go
@@ -806,7 +806,9 @@ func (z *Fixed256bit) lshOne() {
 
 // Lsh sets z = x << n and returns z.
 func (z *Fixed256bit) Lsh(x *Fixed256bit, n uint) *Fixed256bit {
-
+	var (
+		a, b uint64
+	)
 	// Big swaps first
 	switch {
 	case n >= 256:
@@ -814,12 +816,15 @@ func (z *Fixed256bit) Lsh(x *Fixed256bit, n uint) *Fixed256bit {
 	case n >= 192:
 		z.lsh192(x)
 		n -= 192
+		goto sh192
 	case n >= 128:
 		z.lsh128(x)
 		n -= 128
+		goto sh128
 	case n >= 64:
 		z.lsh64(x)
 		n -= 64
+		goto sh64
 	default:
 		z.Copy(x)
 	}
@@ -827,18 +832,18 @@ func (z *Fixed256bit) Lsh(x *Fixed256bit, n uint) *Fixed256bit {
 		return z
 	}
 	// remaining shifts
-	var (
-		a, b uint64
-	)
 	a = z.d >> (64 - n)
 	z.d = z.d << n
 
+sh64:
 	b = z.c >> (64 - n)
 	z.c = (z.c << n) | a
 
+sh128:
 	a = z.b >> (64 - n)
 	z.b = (z.b << n) | b
 
+sh192:
 	b = z.a >> (64 - n)
 	z.a = (z.a << n) | a
 	return z
@@ -846,7 +851,9 @@ func (z *Fixed256bit) Lsh(x *Fixed256bit, n uint) *Fixed256bit {
 
 // Rsh sets z = x >> n and returns z.
 func (z *Fixed256bit) Rsh(x *Fixed256bit, n uint) *Fixed256bit {
-
+	var (
+		a, b uint64
+	)
 	// Big swaps first
 	switch {
 	case n >= 256:
@@ -854,12 +861,15 @@ func (z *Fixed256bit) Rsh(x *Fixed256bit, n uint) *Fixed256bit {
 	case n >= 192:
 		z.rsh192(x)
 		n -= 192
+		goto sh192
 	case n >= 128:
 		z.rsh128(x)
 		n -= 128
+		goto sh128
 	case n >= 64:
 		z.rsh64(x)
 		n -= 64
+		goto sh64
 	default:
 		z.Copy(x)
 	}
@@ -868,19 +878,18 @@ func (z *Fixed256bit) Rsh(x *Fixed256bit, n uint) *Fixed256bit {
 	}
 
 	// remaining shifts
-	var (
-		a, b uint64
-	)
-
 	a = z.a << (64 - n)
 	z.a = z.a >> n
 
+sh64:
 	b = z.b << (64 - n)
 	z.b = (z.b >> n) | a
 
+sh128:
 	a = z.c << (64 - n)
 	z.c = (z.c >> n) | b
 
+sh192:
 	b = z.d << (64 - n)
 	z.d = (z.d >> n) | a
 

--- a/fixedbig.go
+++ b/fixedbig.go
@@ -819,28 +819,24 @@ func (z *Fixed256bit) Lsh(x *Fixed256bit, n uint) *Fixed256bit {
 		n -= 192
 		goto sh192
 	case n == 192:
-		z.lsh192(x)
-		return z
+		return z.lsh192(x)
 
 	case n > 128:
 		z.lsh128(x)
 		n -= 128
 		goto sh128
 	case n == 128:
-		z.lsh128(x)
-		return z
+		return z.lsh128(x)
 
 	case n > 64:
 		z.lsh64(x)
 		n -= 64
 		goto sh64
 	case n == 64:
-		z.lsh64(x)
-		return z
+		return z.lsh64(x)
 
 	case n == 0:
-		z.Copy(x)
-		return z
+		return z.Copy(x)
 	default:
 		z.Copy(x)
 	}
@@ -876,28 +872,24 @@ func (z *Fixed256bit) Rsh(x *Fixed256bit, n uint) *Fixed256bit {
 		n -= 192
 		goto sh192
 	case n == 192:
-		z.rsh192(x)
-		return z
+		return z.rsh192(x)
 
 	case n > 128:
 		z.rsh128(x)
 		n -= 128
 		goto sh128
 	case n == 128:
-		z.rsh128(x)
-		return z
+		return z.rsh128(x)
 
 	case n > 64:
 		z.rsh64(x)
 		n -= 64
 		goto sh64
 	case n == 64:
-		z.rsh64(x)
-		return z
+		return z.rsh64(x)
 
 	case n == 0:
-		z.Copy(x)
-		return z
+		return z.Copy(x)
 	default:
 		z.Copy(x)
 	}

--- a/fixedbig.go
+++ b/fixedbig.go
@@ -806,9 +806,6 @@ func (z *Fixed256bit) lshOne() {
 
 // Lsh sets z = x << n and returns z.
 func (z *Fixed256bit) Lsh(x *Fixed256bit, n uint) *Fixed256bit {
-	if n == 0 {
-		return z
-	}
 	var (
 		a, b uint64
 	)
@@ -816,18 +813,34 @@ func (z *Fixed256bit) Lsh(x *Fixed256bit, n uint) *Fixed256bit {
 	switch {
 	case n >= 256:
 		return z.Clear()
-	case n >= 192:
+
+	case n > 192:
 		z.lsh192(x)
 		n -= 192
 		goto sh192
-	case n >= 128:
+	case n == 192:
+		z.lsh192(x)
+		return z
+
+	case n > 128:
 		z.lsh128(x)
 		n -= 128
 		goto sh128
-	case n >= 64:
+	case n == 128:
+		z.lsh128(x)
+		return z
+
+	case n > 64:
 		z.lsh64(x)
 		n -= 64
 		goto sh64
+	case n == 64:
+		z.lsh64(x)
+		return z
+
+	case n == 0:
+		z.Copy(x)
+		return z
 	default:
 		z.Copy(x)
 	}
@@ -844,16 +857,12 @@ sh128:
 	z.b = (z.b << n) | b
 
 sh192:
-	b = z.a >> (64 - n)
 	z.a = (z.a << n) | a
 	return z
 }
 
 // Rsh sets z = x >> n and returns z.
 func (z *Fixed256bit) Rsh(x *Fixed256bit, n uint) *Fixed256bit {
-	if n == 0 {
-		return z
-	}
 	var (
 		a, b uint64
 	)
@@ -861,18 +870,34 @@ func (z *Fixed256bit) Rsh(x *Fixed256bit, n uint) *Fixed256bit {
 	switch {
 	case n >= 256:
 		return z.Clear()
-	case n >= 192:
+
+	case n > 192:
 		z.rsh192(x)
 		n -= 192
 		goto sh192
-	case n >= 128:
+	case n == 192:
+		z.rsh192(x)
+		return z
+
+	case n > 128:
 		z.rsh128(x)
 		n -= 128
 		goto sh128
-	case n >= 64:
+	case n == 128:
+		z.rsh128(x)
+		return z
+
+	case n > 64:
 		z.rsh64(x)
 		n -= 64
 		goto sh64
+	case n == 64:
+		z.rsh64(x)
+		return z
+
+	case n == 0:
+		z.Copy(x)
+		return z
 	default:
 		z.Copy(x)
 	}
@@ -890,7 +915,6 @@ sh128:
 	z.c = (z.c >> n) | b
 
 sh192:
-	b = z.d << (64 - n)
 	z.d = (z.d >> n) | a
 
 	return z

--- a/fixedbig.go
+++ b/fixedbig.go
@@ -806,6 +806,9 @@ func (z *Fixed256bit) lshOne() {
 
 // Lsh sets z = x << n and returns z.
 func (z *Fixed256bit) Lsh(x *Fixed256bit, n uint) *Fixed256bit {
+	if n == 0 {
+		return z
+	}
 	var (
 		a, b uint64
 	)
@@ -828,9 +831,6 @@ func (z *Fixed256bit) Lsh(x *Fixed256bit, n uint) *Fixed256bit {
 	default:
 		z.Copy(x)
 	}
-	if n == 0 {
-		return z
-	}
 	// remaining shifts
 	a = z.d >> (64 - n)
 	z.d = z.d << n
@@ -851,6 +851,9 @@ sh192:
 
 // Rsh sets z = x >> n and returns z.
 func (z *Fixed256bit) Rsh(x *Fixed256bit, n uint) *Fixed256bit {
+	if n == 0 {
+		return z
+	}
 	var (
 		a, b uint64
 	)
@@ -872,9 +875,6 @@ func (z *Fixed256bit) Rsh(x *Fixed256bit, n uint) *Fixed256bit {
 		goto sh64
 	default:
 		z.Copy(x)
-	}
-	if n == 0 {
-		return z
 	}
 
 	// remaining shifts

--- a/fixedbig_test.go
+++ b/fixedbig_test.go
@@ -645,7 +645,7 @@ func benchmark_Rsh_Bit(bench *testing.B) {
 	bench.ResetTimer()
 	for i := 0; i < bench.N; i++ {
 		f1 := NewFixed()
-		f1.Lsh(f2, n)
+		f1.Rsh(f2, n)
 	}
 }
 func Benchmark_Rsh(bench *testing.B) {


### PR DESCRIPTION
`Benchmark_Lsh`
20000000	        98.2 ns/op
300000000	         4.69 ns/op compared to 7.27 ns/op
PASS

`Benchmark_Rsh`
20000000	        81.5 ns/op
300000000	         4.70 ns/op compared to 7.22 ns/op
PASS