### PR TITLE
Lsh, Rsh: separate case n mod 64 = 0, extend benchmarks

### DIFF
--- a/fixedbig.go
+++ b/fixedbig.go
@@ -806,40 +806,44 @@ func (z *Fixed256bit) lshOne() {
 
 // Lsh sets z = x << n and returns z.
 func (z *Fixed256bit) Lsh(x *Fixed256bit, n uint) *Fixed256bit {
+	// n % 64 == 0
+	if n & 0x3f == 0 {
+		switch n {
+		case 0:
+			return z.Copy(x)
+		case 64:
+			return z.lsh64(x)
+		case 128:
+			return z.lsh128(x)
+		case 192:
+			return z.lsh192(x)
+		default:
+			return z.Clear()
+		}
+	}
 	var (
 		a, b uint64
 	)
 	// Big swaps first
 	switch {
-	case n >= 256:
+	case n > 256:
 		return z.Clear()
-
 	case n > 192:
 		z.lsh192(x)
 		n -= 192
 		goto sh192
-	case n == 192:
-		return z.lsh192(x)
-
 	case n > 128:
 		z.lsh128(x)
 		n -= 128
 		goto sh128
-	case n == 128:
-		return z.lsh128(x)
-
 	case n > 64:
 		z.lsh64(x)
 		n -= 64
 		goto sh64
-	case n == 64:
-		return z.lsh64(x)
-
-	case n == 0:
-		return z.Copy(x)
 	default:
 		z.Copy(x)
 	}
+
 	// remaining shifts
 	a = z.d >> (64 - n)
 	z.d = z.d << n
@@ -854,42 +858,46 @@ sh128:
 
 sh192:
 	z.a = (z.a << n) | a
+
 	return z
 }
 
 // Rsh sets z = x >> n and returns z.
 func (z *Fixed256bit) Rsh(x *Fixed256bit, n uint) *Fixed256bit {
+	// n % 64 == 0
+	if n & 0x3f == 0 {
+		switch n {
+		case 0:
+			return z.Copy(x)
+		case 64:
+			return z.rsh64(x)
+		case 128:
+			return z.rsh128(x)
+		case 192:
+			return z.rsh192(x)
+		default:
+			return z.Clear()
+		}
+	}
 	var (
 		a, b uint64
 	)
 	// Big swaps first
 	switch {
-	case n >= 256:
+	case n > 256:
 		return z.Clear()
-
 	case n > 192:
 		z.rsh192(x)
 		n -= 192
 		goto sh192
-	case n == 192:
-		return z.rsh192(x)
-
 	case n > 128:
 		z.rsh128(x)
 		n -= 128
 		goto sh128
-	case n == 128:
-		return z.rsh128(x)
-
 	case n > 64:
 		z.rsh64(x)
 		n -= 64
 		goto sh64
-	case n == 64:
-		return z.rsh64(x)
-
-	case n == 0:
-		return z.Copy(x)
 	default:
 		z.Copy(x)
 	}

--- a/fixedbig_test.go
+++ b/fixedbig_test.go
@@ -605,18 +605,31 @@ func Benchmark_Cmp(bench *testing.B) {
 }
 
 
-func benchmark_Lsh_Big(bench *testing.B) {
+func benchmark_Lsh_Big(n uint, bench *testing.B) {
 	original := big.NewInt(0).SetBytes(common.Hex2Bytes("FBCDEF090807060504030201ffffffffFBCDEF090807060504030201ffffffff"))
-	n := uint(255)
 	bench.ResetTimer()
 	for i := 0; i < bench.N; i++ {
 		b1 := big.NewInt(0)
 		b1.Lsh(original, n)
 	}
 }
-func benchmark_Lsh_Bit(bench *testing.B) {
+func benchmark_Lsh_Big_N_EQ_0(bench *testing.B) {
+	benchmark_Lsh_Big(0, bench)
+}
+func benchmark_Lsh_Big_N_GT_192(bench *testing.B) {
+	benchmark_Lsh_Big(193, bench)
+}
+func benchmark_Lsh_Big_N_GT_128(bench *testing.B) {
+	benchmark_Lsh_Big(129, bench)
+}
+func benchmark_Lsh_Big_N_GT_64(bench *testing.B) {
+	benchmark_Lsh_Big(65, bench)
+}
+func benchmark_Lsh_Big_N_GT_0(bench *testing.B) {
+	benchmark_Lsh_Big(1, bench)
+}
+func benchmark_Lsh_Bit(n uint, bench *testing.B) {
 	original := big.NewInt(0).SetBytes(common.Hex2Bytes("FBCDEF090807060504030201ffffffffFBCDEF090807060504030201ffffffff"))
-	n := uint(255)
 	f2, _ := NewFixedFromBig(original)
 	bench.ResetTimer()
 	for i := 0; i < bench.N; i++ {
@@ -624,33 +637,94 @@ func benchmark_Lsh_Bit(bench *testing.B) {
 		f1.Lsh(f2, n)
 	}
 }
+func benchmark_Lsh_Bit_N_EQ_0(bench *testing.B) {
+	benchmark_Lsh_Bit(0, bench)
+}
+func benchmark_Lsh_Bit_N_GT_192(bench *testing.B) {
+	benchmark_Lsh_Bit(193, bench)
+}
+func benchmark_Lsh_Bit_N_GT_128(bench *testing.B) {
+	benchmark_Lsh_Bit(129, bench)
+}
+func benchmark_Lsh_Bit_N_GT_64(bench *testing.B) {
+	benchmark_Lsh_Bit(65, bench)
+}
+func benchmark_Lsh_Bit_N_GT_0(bench *testing.B) {
+	benchmark_Lsh_Bit(1, bench)
+}
 func Benchmark_Lsh(bench *testing.B) {
-	bench.Run("big", benchmark_Lsh_Big)
-	bench.Run("fixedbit", benchmark_Lsh_Bit)
+	bench.Run("big/n_eq_0", benchmark_Lsh_Big_N_EQ_0)
+	bench.Run("big/n_gt_192", benchmark_Lsh_Big_N_GT_192)
+	bench.Run("big/n_gt_128", benchmark_Lsh_Big_N_GT_128)
+	bench.Run("big/n_gt_64", benchmark_Lsh_Big_N_GT_64)
+	bench.Run("big/n_gt_0", benchmark_Lsh_Big_N_GT_0)
+
+	bench.Run("fixedbit/n_eq_0", benchmark_Lsh_Bit_N_EQ_0)
+	bench.Run("fixedbit/n_gt_192", benchmark_Lsh_Bit_N_GT_192)
+	bench.Run("fixedbit/n_gt_128", benchmark_Lsh_Bit_N_GT_128)
+	bench.Run("fixedbit/n_gt_64", benchmark_Lsh_Bit_N_GT_64)
+	bench.Run("fixedbit/n_gt_0", benchmark_Lsh_Bit_N_GT_0)
 }
 
-func benchmark_Rsh_Big(bench *testing.B) {
+func benchmark_Rsh_Big(n uint, bench *testing.B) {
 	original := big.NewInt(0).SetBytes(common.Hex2Bytes("FBCDEF090807060504030201ffffffffFBCDEF090807060504030201ffffffff"))
-	n := uint(255)
 	bench.ResetTimer()
 	for i := 0; i < bench.N; i++ {
 		b1 := big.NewInt(0)
 		b1.Rsh(original, n)
 	}
 }
-func benchmark_Rsh_Bit(bench *testing.B) {
+func benchmark_Rsh_Big_N_EQ_0(bench *testing.B) {
+	benchmark_Rsh_Big(0, bench)
+}
+func benchmark_Rsh_Big_N_GT_192(bench *testing.B) {
+	benchmark_Rsh_Big(193, bench)
+}
+func benchmark_Rsh_Big_N_GT_128(bench *testing.B) {
+	benchmark_Rsh_Big(129, bench)
+}
+func benchmark_Rsh_Big_N_GT_64(bench *testing.B) {
+	benchmark_Rsh_Big(65, bench)
+}
+func benchmark_Rsh_Big_N_GT_0(bench *testing.B) {
+	benchmark_Rsh_Big(1, bench)
+}
+func benchmark_Rsh_Bit(n uint, bench *testing.B) {
 	original := big.NewInt(0).SetBytes(common.Hex2Bytes("FBCDEF090807060504030201ffffffffFBCDEF090807060504030201ffffffff"))
 	f2, _ := NewFixedFromBig(original)
-	n := uint(255)
 	bench.ResetTimer()
 	for i := 0; i < bench.N; i++ {
 		f1 := NewFixed()
 		f1.Rsh(f2, n)
 	}
 }
+func benchmark_Rsh_Bit_N_EQ_0(bench *testing.B) {
+	benchmark_Rsh_Bit(0, bench)
+}
+func benchmark_Rsh_Bit_N_GT_192(bench *testing.B) {
+	benchmark_Rsh_Bit(193, bench)
+}
+func benchmark_Rsh_Bit_N_GT_128(bench *testing.B) {
+	benchmark_Rsh_Bit(129, bench)
+}
+func benchmark_Rsh_Bit_N_GT_64(bench *testing.B) {
+	benchmark_Rsh_Bit(65, bench)
+}
+func benchmark_Rsh_Bit_N_GT_0(bench *testing.B) {
+	benchmark_Rsh_Bit(1, bench)
+}
 func Benchmark_Rsh(bench *testing.B) {
-	bench.Run("big", benchmark_Rsh_Big)
-	bench.Run("fixedbit", benchmark_Rsh_Bit)
+	bench.Run("big/n_eq_0", benchmark_Rsh_Big_N_EQ_0)
+	bench.Run("big/n_gt_192", benchmark_Rsh_Big_N_GT_192)
+	bench.Run("big/n_gt_128", benchmark_Rsh_Big_N_GT_128)
+	bench.Run("big/n_gt_64", benchmark_Rsh_Big_N_GT_64)
+	bench.Run("big/n_gt_0", benchmark_Rsh_Big_N_GT_0)
+
+	bench.Run("fixedbit/n_eq_0", benchmark_Rsh_Bit_N_EQ_0)
+	bench.Run("fixedbit/n_gt_192", benchmark_Rsh_Bit_N_GT_192)
+	bench.Run("fixedbit/n_gt_128", benchmark_Rsh_Bit_N_GT_128)
+	bench.Run("fixedbit/n_gt_64", benchmark_Rsh_Bit_N_GT_64)
+	bench.Run("fixedbit/n_gt_0", benchmark_Rsh_Bit_N_GT_0)
 }
 
 func benchmark_Exp_Big(bench *testing.B) {


### PR DESCRIPTION
The separation of `n mod 64 = 0` case reduces the general number of comparisons.

The shift benchmarks only represent `192 < n < 256`, I tried to make benchmarks for the other cases too.

```
Benchmark_Lsh/big/n_eq_0-8         	20000000	       145 ns/op	     112 B/op	       2 allocs/op
Benchmark_Lsh/big/n_gt_192-8       	20000000	       146 ns/op	     128 B/op	       2 allocs/op
Benchmark_Lsh/big/n_gt_128-8       	10000000	       160 ns/op	     128 B/op	       2 allocs/op
Benchmark_Lsh/big/n_gt_64-8        	10000000	       149 ns/op	     112 B/op	       2 allocs/op
Benchmark_Lsh/big/n_gt_0-8         	10000000	       182 ns/op	     112 B/op	       2 allocs/op
Benchmark_Lsh/fixedbit/n_eq_0-8    	500000000	         3.35 ns/op	       0 B/op	       0 allocs/op
Benchmark_Lsh/fixedbit/n_gt_192-8  	500000000	         3.72 ns/op	       0 B/op	       0 allocs/op
Benchmark_Lsh/fixedbit/n_gt_128-8  	300000000	         5.22 ns/op	       0 B/op	       0 allocs/op
Benchmark_Lsh/fixedbit/n_gt_64-8   	200000000	         7.45 ns/op	       0 B/op	       0 allocs/op
Benchmark_Lsh/fixedbit/n_gt_0-8    	200000000	         8.90 ns/op	       0 B/op	       0 allocs/op

Benchmark_Rsh/big/n_eq_0-8         	20000000	       101 ns/op	      96 B/op	       2 allocs/op
Benchmark_Rsh/big/n_gt_192-8       	20000000	       113 ns/op	      80 B/op	       2 allocs/op
Benchmark_Rsh/big/n_gt_128-8       	20000000	       114 ns/op	      80 B/op	       2 allocs/op
Benchmark_Rsh/big/n_gt_64-8        	20000000	        89.5 ns/op	      96 B/op	       2 allocs/op
Benchmark_Rsh/big/n_gt_0-8         	20000000	       115 ns/op	      96 B/op	       2 allocs/op
Benchmark_Rsh/fixedbit/n_eq_0-8    	500000000	         3.56 ns/op	       0 B/op	       0 allocs/op
Benchmark_Rsh/fixedbit/n_gt_192-8  	500000000	         3.86 ns/op	       0 B/op	       0 allocs/op
Benchmark_Rsh/fixedbit/n_gt_128-8  	300000000	         5.40 ns/op	       0 B/op	       0 allocs/op
Benchmark_Rsh/fixedbit/n_gt_64-8   	200000000	         7.33 ns/op	       0 B/op	       0 allocs/op
Benchmark_Rsh/fixedbit/n_gt_0-8    	200000000	         8.89 ns/op	       0 B/op	       0 allocs/op
```